### PR TITLE
feat: add custom invite whisper

### DIFF
--- a/EasyPartyInvite.toc
+++ b/EasyPartyInvite.toc
@@ -3,4 +3,5 @@
 ## Notes: Prompt to invite nearby friendly players based on combat log
 ## Author: Yaya RJB
 ## Version: 0.1.0
+## SavedVariables: EPI_Settings
 EasyPartyInvite.lua

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ EasyPartyInvite is a lightweight World of Warcraft addon for Mists of Pandaria C
 ## Usage
 - Click the minimap button or type `/epi toggle` to enable or disable auto-invite mode.
 - Use `/epi status` to check whether auto-invite mode is currently enabled.
+ - Enable a custom whisper in the addon options or set it with `/epi message <text>`. The message will be sent as `EasyPartyInvite: <text>` when inviting a player via the popup.
 


### PR DESCRIPTION
## Summary
- allow players to configure a whisper sent on accepting an invite
- store whisper text and enable state in saved variables
- expose whisper configuration in addon options with a checkbox and message input
- document `/epi message` command

## Testing
- `luac -p EasyPartyInvite.lua`


------
https://chatgpt.com/codex/tasks/task_e_6896893b067483339d4e737924d2f528