### PR TITLE
Add CurseForge release workflow

### DIFF
--- a/.github/workflows/curseforge.yml
+++ b/.github/workflows/curseforge.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Package and upload to CurseForge
+        uses: BigWigsMods/packager@v2
+        with:
+          args: "-p ${{ secrets.CF_PROJECT_ID }}"
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ NearbyPartyInvite is a lightweight World of Warcraft addon for Mists of Pandaria
 - Use `/npi status` to check whether auto-invite mode is currently enabled.
 - Enable a custom whisper in the addon options or set it with `/npi message <text>`. The message will be sent as `NearbyPartyInvite: <text>` when inviting a player via the popup.
 
+
+## Releasing
+
+This project uses [BigWigsMods/packager](https://github.com/BigWigsMods/packager) to build and publish releases to CurseForge. Pushing a Git tag will trigger the workflow defined in `.github/workflows/curseforge.yml`.
+
+Set the `CF_API_KEY` and `CF_PROJECT_ID` repository secrets to enable uploads to your CurseForge project.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using BigWigsMods/packager to upload releases to CurseForge
- document release workflow and required secrets in README

## Testing
- `luac -p NearbyPartyInvite.lua`
- `python - <<'PY'
import yaml
with open('.github/workflows/curseforge.yml') as f:
    data = yaml.safe_load(f)
print('YAML keys:', list(data.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68973fdd84488333afe9cf2fc77e3713