### PR TITLE
feat: make invite triggers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NearbyPartyInvite
 
-NearbyPartyInvite is a lightweight World of Warcraft addon for Mists of Pandaria Classic that helps you quickly invite nearby friendly players engaged in the same combat activities.
+NearbyPartyInvite is a lightweight World of Warcraft addon for Mists of Pandaria Classic that helps you quickly invite players of your faction that you encounter through combat, targeting, or mouseover.
 
 ## Installation
 Install through [CurseForge](https://www.curseforge.com/wow/addons/nearby-party-invite) using your preferred addon manager. For manual installation, copy the `NearbyPartyInvite` folder into your World of Warcraft `Interface/AddOns` directory and restart the game.
@@ -9,6 +9,7 @@ Install through [CurseForge](https://www.curseforge.com/wow/addons/nearby-party-
 - Click the minimap button or type `/npi toggle` to enable or disable auto-invite mode.
 - Right-click the minimap button to open the addon settings.
 - Use `/npi status` to check whether auto-invite mode is currently enabled.
-- Enable a custom whisper in the addon options or set it with `/npi message <text>`. The message will be sent as `NearbyPartyInvite: <text>` when inviting a player via the popup.
+- Enable a custom whisper in the addon options or set it with `/npi message <text>`. The message will be sent as `NearbyPartyInvite: <text>` after an invitation is sent unless the player is already in a group.
+- In the addon settings, toggle whether scanning occurs on mouseover and target changes.
 
 


### PR DESCRIPTION
## Summary
- let users toggle scanning on mouseover and target change
- skip invite scans when the party is full and cancel whispers when targets are already grouped
- whisper invitees shortly after sending an invitation rather than on group join

## Testing
- `luac -p NearbyPartyInvite.lua` *(fails: command not found)*
- `apt-get install -y lua5.1` *(unable to locate package)*
- `luac -p NearbyPartyInvite.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ab536bb883339bfdba69a648f2b9