### PR TITLE
Remove minimap right-click settings and tag 1.0.0

### DIFF
--- a/NearbyPartyInvite.lua
+++ b/NearbyPartyInvite.lua
@@ -318,13 +318,7 @@ NPI_MinimapIcon:SetPoint("CENTER")
 NPI_MinimapIcon:SetDesaturated(true)
 
 NPI_MinimapButton:SetScript("OnClick", function(_, button)
-    if button == "RightButton" then
-        if Settings and Settings.OpenToCategory then
-            Settings.OpenToCategory(NPI_SettingsCategory and NPI_SettingsCategory.ID or "NearbyPartyInvite")
-        elseif InterfaceOptionsFrame_OpenToCategory then
-            InterfaceOptionsFrame_OpenToCategory(NPI_Options)
-        end
-    else
+    if button == "LeftButton" then
         NPI_Addon:Toggle()
     end
 end)
@@ -333,7 +327,6 @@ NPI_MinimapButton:SetScript("OnEnter", function(self)
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
     GameTooltip:SetText("NearbyPartyInvite")
     GameTooltip:AddLine("Left-click to toggle auto-invite mode", 1, 1, 1)
-    GameTooltip:AddLine("Right-click to open settings", 1, 1, 1)
     GameTooltip:Show()
 end)
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 ## Usage
 
-Enable auto-invite mode with the minimap button or `/npi toggle`. When active, the addon listens for friendly players you encounter and offers to invite them. Use `/npi status` to check the current state, `/npi message <text>` to set a custom whisper, and right-click the minimap button to adjust options like scanning on mouseover or target changes.
-Use `/npi verbosity <level>` to control chat output verbosity.
+Enable auto-invite mode with the minimap button or `/npi toggle`. When active, the addon listens for friendly players you encounter and offers to invite them. Use `/npi status` to check the current state and `/npi message <text>` to set a custom whisper. Open the interface options to adjust settings like scanning on mouseover or target changes. Use `/npi verbosity <level>` to control chat output verbosity.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove right-click settings access from minimap button
- update usage docs for settings access
- add 1.0.0 tag

## Testing
- `luac -p NearbyPartyInvite.lua`


------
https://chatgpt.com/codex/tasks/task_e_689897c2147c8333b7cb6a344393cb67