### PR TITLE
Add CurseForge release workflow for NPI

### DIFF
--- a/.github/workflows/curseforge.yml
+++ b/.github/workflows/curseforge.yml
@@ -1,19 +1,18 @@
-name: Release
+name: CurseForge Release
 
 on:
   push:
     tags:
       - '*'
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Package and upload to CurseForge
+      - name: Package and upload
         uses: BigWigsMods/packager@v2
+        with:
+          args: -p 1324134
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to package and upload NPI to CurseForge using project id 1324134

## Testing
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_689915ff9e488333bb4ce37d1dca9f9d