### PR TITLE
docs: add supported languages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ Enable auto-invite mode with the minimap button or `/npi toggle`. When active, t
 
 ---
 
+## Supported Languages
+
+NearbyPartyInvite is localized in the following languages:
+
+- English (US/GB)
+- French
+- German
+- Spanish (Spain)
+- Spanish (Mexico)
+- Italian
+- Portuguese (Brazil)
+- Russian
+- Korean
+- Chinese (Simplified)
+- Chinese (Traditional)
+
+---
+
 ## Data Storage
 
 - Uses per-account saved variables (`NPI_Settings`)


### PR DESCRIPTION
## Summary
- document supported language localizations in README

## Testing
- `luac -p NearbyPartyInvite.lua Localization.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899e7596b9c83338d6a1aeff9d37e93