### PR TITLE
fix: remove addon name from whisper message

### DIFF
--- a/NearbyPartyInvite.lua
+++ b/NearbyPartyInvite.lua
@@ -199,7 +199,7 @@ StaticPopupDialogs["NPI_CONFIRM_INVITE"] = {
               NPI_PendingWhisper = data.name
               C_Timer.After(1, function()
                   if NPI_PendingWhisper == data.name then
-                    SendChatMessage(L.ADDON_TITLE .. ": " .. NPI_Settings.whisperMessage, "WHISPER", nil, data.name)
+                    SendChatMessage(NPI_Settings.whisperMessage, "WHISPER", nil, data.name)
                     NPI_PendingWhisper = nil
                 end
             end)


### PR DESCRIPTION
## Summary
- stop prefixing custom whispers with NearbyPartyInvite title

## Testing
- `lua -e "assert(loadfile('NearbyPartyInvite.lua'))" && lua -e "assert(loadfile('Localization.lua'))"` *(fails: command not found)*
- `apt-get install -y lua5.4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a239ad893483338c58badf98dd91a1